### PR TITLE
feat: Add default implementation for RelationIdentity.getType() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,6 @@ public class Person implements RelationIdentity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Override
-    public String getType() {
-        return "PersonType";
-    }
 }
 ```
 
@@ -121,7 +116,7 @@ public class DisabledRelationEntity {
 
 ## <a name="RelationIdentity"></a> Implement RelationIdentity
 
-Implement the relationIdentity, each dynamic relation need a Long id and a String Type which you can define.
+Implement the relationIdentity, each dynamic relation need a Long id which you can define.
 
 ```java
 
@@ -134,11 +129,6 @@ public class Person implements RelationIdentity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Override
-    public String getType() {
-        return "PersonType";
-    }
 }
 
 ```

--- a/dynamic-relations/src/main/java/at/drm/model/RelationIdentity.java
+++ b/dynamic-relations/src/main/java/at/drm/model/RelationIdentity.java
@@ -4,6 +4,13 @@ public interface RelationIdentity {
 
     Long getId();
 
-    String getType();
-
+    /**
+     * Returns the type of the relation identity.
+     * This is used to identify the type of the relation in a generic way.
+     *
+     * @return the type of the relation identity
+     */
+    default String getType() {
+        return this.getClass().getSimpleName() + "Type";
+    }
 }

--- a/testing/src/main/java/at/test/drm/AnnotationTest.java
+++ b/testing/src/main/java/at/test/drm/AnnotationTest.java
@@ -17,9 +17,4 @@ public class AnnotationTest implements RelationIdentity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Override
-    public String getType() {
-        return "TestType";
-    }
 }

--- a/testing/src/main/java/at/test/drm/AnnotationTest2.java
+++ b/testing/src/main/java/at/test/drm/AnnotationTest2.java
@@ -17,9 +17,4 @@ public class AnnotationTest2 implements RelationIdentity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Override
-    public String getType() {
-        return "AnnotationType2";
-    }
 }

--- a/testing/src/main/java/at/test/drm/AnnotationTest3.java
+++ b/testing/src/main/java/at/test/drm/AnnotationTest3.java
@@ -17,9 +17,4 @@ public class AnnotationTest3 implements RelationIdentity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Override
-    public String getType() {
-        return "AnnotationType3";
-    }
 }


### PR DESCRIPTION
## Describe your changes

Added a default implementation of the getType() method that returns the class simple name with "Type" suffix.

## Issue ticket number and link

https://github.com/Mom0aut/DynamicRelations/issues/47

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] I have made corresponding changes to the documentation
- [x] I used the given Project Style Guide
